### PR TITLE
add support for registering command handlers by object type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ nuget-cmdline
 Help
 
 .vs
+
+#Rider
+.idea

--- a/Source/AzureFromTheTrenches.Commanding.Abstractions/ICommandRegistry.cs
+++ b/Source/AzureFromTheTrenches.Commanding.Abstractions/ICommandRegistry.cs
@@ -15,6 +15,14 @@ namespace AzureFromTheTrenches.Commanding.Abstractions
             where TCommandHandler : ICommandHandlerBase;
 
         /// <summary>
+        /// Register an handler against a command with no expected result
+        /// </summary>
+        /// <param name="dispatcherFactoryFunc">Optional command dispatcher factory function</param>
+        /// <param name="commandHandlerType">The type of the command handler</param>
+        /// <param name="order">Execution order of the handler</param>
+        ICommandRegistry Register(Type commandHandlerType, int order = CommandHandlerOrder.Default, Func<ICommandDispatcher> dispatcherFactoryFunc = null);
+
+        /// <summary>
         /// Register a command with a dispatcher but no handler. Typically this is used when the command actors are known to be deferred via a queue
         /// or that are remotely executed
         /// </summary>

--- a/Tests/AzureFromTheTrenches.Commanding.Tests.Unit/Implementation/CommandRegistryTests.cs
+++ b/Tests/AzureFromTheTrenches.Commanding.Tests.Unit/Implementation/CommandRegistryTests.cs
@@ -11,7 +11,7 @@ namespace AzureFromTheTrenches.Commanding.Tests.Unit.Implementation
     public class CommandRegistryTests
     {
         [Fact]
-        public void SimpleRegistryIsRecorded()
+        public void SimpleCommandHandlerIsRegisteredByGenericType()
         {
             // Arrange
             var registry = new CommandRegistry(new Mock<ICommandHandlerExecuter>().Object);
@@ -22,6 +22,33 @@ namespace AzureFromTheTrenches.Commanding.Tests.Unit.Implementation
             // Assert
             var result = registry.GetPrioritisedCommandHandlers(new SimpleCommand());
             Assert.Equal(typeof(SimpleCommandHandler), result.Single().CommandHandlerType);
+        }
+        
+        [Fact]
+        public void SimpleCommandHandlerIsRegisteredByObjectType()
+        {
+            // Arrange
+            var registry = new CommandRegistry(new Mock<ICommandHandlerExecuter>().Object);
+
+            // Act
+            registry.Register(typeof(SimpleCommandHandler));
+
+            // Assert
+            var result = registry.GetPrioritisedCommandHandlers(new SimpleCommand());
+            Assert.Equal(typeof(SimpleCommandHandler), result.Single().CommandHandlerType);
+        }
+        
+        [Fact]
+        public void SimpleCommandHandlerThatDoesntImplementBaseClassThrowsCommandRegistrationException()
+        {
+            // Arrange
+            var registry = new CommandRegistry(new Mock<ICommandHandlerExecuter>().Object);
+
+            // Act / Assert
+            Assert.Throws<CommandRegistrationException>(() =>
+            {
+                registry.Register(typeof(SimpleCommandNoImplementaion));
+            });
         }
 
         [Fact]

--- a/Tests/AzureFromTheTrenches.Commanding.Tests.Unit/TestModel/SimpleCommandNoImplementaion.cs
+++ b/Tests/AzureFromTheTrenches.Commanding.Tests.Unit/TestModel/SimpleCommandNoImplementaion.cs
@@ -1,0 +1,7 @@
+﻿namespace AzureFromTheTrenches.Commanding.Tests.Unit.TestModel
+{
+    public class SimpleCommandNoImplementaion
+    {
+        // nothing to see here
+    }
+}


### PR DESCRIPTION
At the moment, you can only add a command handler by generic type.

This change adds the ability to register a command handler by a type object.